### PR TITLE
feat: include cmdb plugin

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,6 +37,18 @@
             "Clone" : true
         },
         {
+            "Id" : "DIAGRAMS",
+            "Repository" : "https://github.com/hamlet-io/engine-plugin-diagrams.git",
+            "Directory" : "engine/plugins/diagrams",
+            "Clone" : true
+        },
+        {
+            "Id" : "CMDB",
+            "Repository" : "https://github.com/hamlet-io/engine-plugin-cmdb.git",
+            "Directory" : "engine/plugins/cmdb",
+            "Clone" : true
+        },
+        {
             "Id" : "BOOTSTRAP",
             "Repository" : "https://github.com/hamlet-io/hamlet-bootstrap.git",
             "Directory" : "bootstrap",
@@ -53,7 +65,7 @@
                 "GENERATION_BASE_DIR" : "/opt/hamlet/executor",
                 "GENERATION_DIR" : "/opt/hamlet/executor/cli",
                 "GENERATION_ENGINE_DIR" : "/opt/hamlet/engine/core",
-                "GENERATION_PLUGIN_DIRS" : "/opt/hamlet/engine/plugins/aws;/opt/hamlet/engine/plugins/azure",
+                "GENERATION_PLUGIN_DIRS" : "/opt/hamlet/engine/plugins/aws;/opt/hamlet/engine/plugins/azure;/opt/hamlet/engine/plugins/diagrams",
                 "GENERATION_PATTERNS_DIR" : "/opt/hamlet/patterns"
             }
         }


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Include the cmdb and diagram plugins in the image.

## Motivation and Context
By including the cmdb plugin, it makes continued testing of its use easier given the auto-detection logic in the bash executor.

Note that because the cmdb plugin is not currently included in the `GENERATION_PLUGIN_DIRS` environment variable, dynamic cmdb processing won't be active by default, but simply by adding it as an extra path value to this variable, dynamic cmdb loading will be activated.

Also add the diagrams plugin to align with what is in the docker container build.

## How Has This Been Tested?
Local testing

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

